### PR TITLE
Adjusted bucket policy to allow the creation of new ELBs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,45 @@ data "aws_iam_policy_document" "bucket_policy" {
   }
 
   statement {
+    sid = "AWSLogDeliveryWrite"
+    actions = [
+      "s3:PutObject"
+    ]
+    principals {
+      identifiers = [
+        "delivery.logs.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    resources = [
+      "${aws_s3_bucket.bucket.arn}/elb/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values = [
+        "bucket-owner-full-control"
+      ]
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+    principals {
+      identifiers = [
+        "delivery.logs.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    resources = [
+      aws_s3_bucket.bucket.arn
+    ]
+    sid = "AWSLogDeliveryAclCheck"
+  }
+
+  statement {
     actions = [
       "s3:GetBucketAcl"
     ]


### PR DESCRIPTION
## Change description

> Previous bucket policy did not allow GetBucketACL which is now required during ELB creation when access logging is enabled.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> [SGINT-169](https://stratusgrid.atlassian.net/browse/SGINT-169)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
