### PR TITLE
Remove ACL for log-deliver-write and use bucket policy instead

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       type = "Service"
     }
     resources = [
-      "${aws_s3_bucket.bucket.arn}/elb/*"
+      "${aws_s3_bucket.bucket.arn}/*"
     ]
     condition {
       test     = "StringEquals"
@@ -137,11 +137,6 @@ resource "aws_s3_bucket_versioning" "resource" {
   versioning_configuration {
     status = var.versioning_enabled == true ? "Enabled" : "Suspended"
   }
-}
-
-resource "aws_s3_bucket_acl" "bucket" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket" {


### PR DESCRIPTION
## Change description

There's the following issue when trying to create the acl for log-delivery-write:

This bucket has the bucket owner enforced setting applied for Object Ownership. When bucket owner enforced is applied, you must use bucket policies to control access. The bucket will not allow the creation of ACLs and return the following error: AccessControlListNotSupported: The bucket does not allow ACLs.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

## Type of change
- [X] Bug fix (fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [X] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
