### PR TITLE
[feature] Allow conditionally disable the encryption configuration

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -40,7 +40,7 @@ content: |-
   {{ include "examples/regional-deployment/example2.tfnot" }}
   ```
 
-   ---
+  ---
 
   {{ .Requirements }}
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ module "iam_role_s3" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_days_to_object_expiration"></a> [days\_to\_object\_expiration](#input\_days\_to\_object\_expiration) | Number of days before expiring data completely | `string` | `"2557"` | no |
 | <a name="input_enable_centralized_logging"></a> [enable\_centralized\_logging](#input\_enable\_centralized\_logging) | Enable support for centralized logging to a centralized logging account | `bool` | `false` | no |
+| <a name="input_enable_encryption"></a> [enable\_encryption](#input\_enable\_encryption) | Allows disable the the bucket encryption configuration | `bool` | `true` | no |
 | <a name="input_enable_object_expiration"></a> [enable\_object\_expiration](#input\_enable\_object\_expiration) | Number of days before expiring data completely | `bool` | `false` | no |
 | <a name="input_iam_role_s3_replication_arn"></a> [iam\_role\_s3\_replication\_arn](#input\_iam\_role\_s3\_replication\_arn) | IAM Role that enable S3 Role Assumption for Centralized Logging | `string` | `""` | no |
 | <a name="input_input_tags"></a> [input\_tags](#input\_input\_tags) | Map of tags to apply to resources | `map(string)` | `{}` | no |

--- a/inputs.tf
+++ b/inputs.tf
@@ -80,3 +80,9 @@ variable "replication_dest_storage_class" {
   type        = string
   default     = "STANDARD_IA"
 }
+
+variable "enable_encryption" {
+  description = "Allows disable the the bucket encryption configuration"
+  type        = bool
+  default     = true
+}

--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
+  count = var.enable_encryption == true ? 1 : 0
+
   bucket = aws_s3_bucket.bucket.bucket
 
   rule {


### PR DESCRIPTION
## Change description

> EPB client has set SCPs in some OUs that don't allow a change in the method encryption in the bucket not even define it in TF files; this change is to address that problem and allows disabling that configuration block in this module. It's not risky because each bucket has as a default method encryption SSE-S3.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
