### PR TITLE
[feature] Allow the selection of the encryption type for the S3 bucket

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -40,7 +40,7 @@ content: |-
   {{ include "examples/regional-deployment/example2.tfnot" }}
   ```
 
-   ---
+  ---
 
   {{ .Requirements }}
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ module "iam_role_s3" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_s3_bucket_server_side_encryption_type"></a> [aws\_s3\_bucket\_server\_side\_encryption\_type](#input\_aws\_s3\_bucket\_server\_side\_encryption\_type) | Selection of the bucket encryption type | `string` | `"SSE_S3"` | no |
 | <a name="input_days_to_object_expiration"></a> [days\_to\_object\_expiration](#input\_days\_to\_object\_expiration) | Number of days before expiring data completely | `string` | `"2557"` | no |
 | <a name="input_enable_centralized_logging"></a> [enable\_centralized\_logging](#input\_enable\_centralized\_logging) | Enable support for centralized logging to a centralized logging account | `bool` | `false` | no |
 | <a name="input_enable_object_expiration"></a> [enable\_object\_expiration](#input\_enable\_object\_expiration) | Number of days before expiring data completely | `bool` | `false` | no |

--- a/inputs.tf
+++ b/inputs.tf
@@ -80,3 +80,20 @@ variable "replication_dest_storage_class" {
   type        = string
   default     = "STANDARD_IA"
 }
+
+variable "aws_s3_bucket_server_side_encryption_type" {
+  description = "Selection of the bucket encryption type"
+  type        = string
+  default     = "SSE_S3"
+
+  validation {
+    condition = contains([
+      "AWS_DEFAULT",
+      "SSE_S3"
+      ],
+      var.aws_s3_bucket_server_side_encryption_type
+    )
+
+    error_message = "The valid values are AWS_DEFAULT, SSE_S3"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -207,12 +207,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 }
 
 #tfsec:ignore:aws-s3-encryption-customer-key
+#trivy:ignore:AVD-AWS-0089
+#trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
-  bucket = aws_s3_bucket.bucket.bucket
+  count = var.aws_s3_bucket_server_side_encryption_type != "AWS_DEFAULT" ? 1 : 0
 
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+  bucket = aws_s3_bucket.bucket.bucket
+  dynamic "rule" {
+    for_each = var.aws_s3_bucket_server_side_encryption_type == "SSE_S3" ? [1] : []
+    content {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
     }
   }
 }


### PR DESCRIPTION
## Change description

> EPB client has set SCPs in some OUs that don't allow a change in the method encryption in the bucket (s3: PutBucketEncryption), not even define it in TF files; this change is to address that problem and allows selecting that configuration block in this module. It's safe because each bucket has as a default method encryption SSE-S3.
- The default value in the variable `aws_s3_bucket_server_side_encryption_type` is SSE_S3 to maintain backward compatibility.
- Trivy ignores were added for `S3 Bucket does not have logging enabled`and `S3 encryption should use Customer Managed Keys`



## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

> Fix [#1](https://stratusgrid.atlassian.net/browse/EPBCHA-41) 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
